### PR TITLE
Fix newline on missing positional argument

### DIFF
--- a/argp/src/error.rs
+++ b/argp/src/error.rs
@@ -137,7 +137,7 @@ impl fmt::Display for MissingRequirements {
         }
 
         if let Some(missing_subcommands) = &self.subcommands {
-            if !self.options.is_empty() {
+            if !self.positional_args.is_empty() || !self.options.is_empty() {
                 f.write_char('\n')?;
             }
             f.write_str("One of the following subcommands must be present:")?;


### PR DESCRIPTION
When both a positional argument and a subcommand are missing, the subcommand did not add the required newline. Example (from `simple_example`):

```rust
/// Top-level command.
#[derive(FromArgs, PartialEq, Debug)]
struct TopLevel {
    /// Foo
    #[argp(positional)]
    foo: String,

    /// Be verbose.
    #[argp(switch, global)]
    verbose: bool,

    #[argp(subcommand)]
    nested: MySubCommandEnum,
}
```

prints

```
Required positional arguments not provided:
    fooOne of the following subcommands must be present:
    help
    one
    two
```

The PR fixes this.

Also thank you for this crate which I use in all my new CLI projects (for the same good reasons as listed in your readme)!